### PR TITLE
cant change to api version 2.4 yet, need to downgrade to 2.3

### DIFF
--- a/lib/facebook_ads_api/client.rb
+++ b/lib/facebook_ads_api/client.rb
@@ -16,7 +16,7 @@ module FacebookAdsApi
     # todos: Change ssl_verify_peer back to true and include cacert.pem.
     DEFAULTS = {
       host: "graph.facebook.com",
-      api_version: "v2.4",
+      api_version: "v2.3",
       port: 443,
       use_ssl: true,
       ssl_verify_peer: false,


### PR DESCRIPTION
oops my mistake, we are not able to switch to version 2.4 due to report stats being deprecated in 2.4+ so we shall downgrade to 2.3 for now until we can come up with a fix.
